### PR TITLE
docs(env): update the dotenv install command

### DIFF
--- a/website/docs/beginner/env.md
+++ b/website/docs/beginner/env.md
@@ -44,7 +44,7 @@ You need to add this flag before the file you want to run also if you have multi
 
 If you don't want or can't use the `--env-file` option you can do it with the `dotenv` package
 
-First of all you need to install the `dotenv` package along it's type if you are using TypeScript
+First of all you need to install the `dotenv` package
 
 `npm install dotenv`
 _or using yarn, pnpm or bun_

--- a/website/docs/beginner/env.md
+++ b/website/docs/beginner/env.md
@@ -46,7 +46,7 @@ If you don't want or can't use the `--env-file` option you can do it with the `d
 
 First of all you need to install the `dotenv` package along it's type if you are using TypeScript
 
-`npm install dotenv @types/dotenv --save-dev`
+`npm install dotenv`
 _or using yarn, pnpm or bun_
 
 We now need to load the `.env` from our code so let's add the following code to your typescript file:


### PR DESCRIPTION
- Removed `@types/dotenv` because it has since been deprecated due to the addition of native types in the `dotenv` package.
- Removed the `--save-dev` flag, which was intended for the types package, even though both ended up being installed as dev dependencies.